### PR TITLE
fix: force browser border radius

### DIFF
--- a/userChrome.css
+++ b/userChrome.css
@@ -39,6 +39,11 @@ General Browser Styling
             border: none !important;
         }
     }
+    body > #appcontent > browser {
+        border-radius: var(--border-radius) !important;
+        border: none !important;
+        clip-path: circle(100%);
+    }
 }
 body > #browser {
     margin-top: calc(-2 * var(--browser-padding));


### PR DESCRIPTION
Adding the clip path to the browser element will fix the issue you mentioned on Reddit where websites can overflow the border radius.