### PR TITLE
Fix broken tab hover styling by removing invalid colon

### DIFF
--- a/userChrome.css
+++ b/userChrome.css
@@ -117,7 +117,7 @@ scrollbox  {
     }
   }
   &:hover {
-    .tab-background: {
+    .tab-background {
       --tab-bg: var(--transparent-bg-light);
       filter: brightness(100%);
     }


### PR DESCRIPTION
The hover styles for browser tabs were not being applied.

In `userChrome.css`, inside the `&:hover` block for `#tabbrowser-tabs tab`, the nested rule was written as:

```css
.tab-background: {
  --tab-bg: var(--transparent-bg-light);
  filter: brightness(100%);
}
```

The trailing colon after `.tab-background` makes that block invalid, so Firefox ignores it. As a result, hovered tabs never receive the intended lighter background/brightness change.

This PR removes that colon so the nested rule becomes valid:
```css
.tab-background {
  --tab-bg: var(--transparent-bg-light);
  filter: brightness(100%);
}
```

After this change, hovering a tab correctly applies the visual hover state.